### PR TITLE
Added team list method that draws from rankings

### DIFF
--- a/frcstat/Event.py
+++ b/frcstat/Event.py
@@ -588,6 +588,9 @@ class Event:
       
     def getTeamList(self):
         return self.teamList
+    
+    def getPlayingTeamList(self):
+        return [int(team['team_key'][3:]) for team in self.rankings['rankings']]
         
 class _Pattern_Variable:
     def __init__(self , name , arrayIndex):


### PR DESCRIPTION
TBA team lists often include no-shows or teams who won an individual award but did not attend. Added method to get the team list from the rankings so only teams who play are included