### PR TITLE
Support macOS and Ubuntu.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 main:
-	python setup.py build
-	python setup.py install
+	python3 setup.py build
+	python3 setup.py install
 	


### PR DESCRIPTION
On most current *nix systems, `python` refers to 2.7 and `python3` refers to 3.6.  If I build with 2.7 I get all sorts of issues.